### PR TITLE
19 teleport confirm notification implemented with yes send teleport request and no do nothing

### DIFF
--- a/frontend/src/components/SocialSidebar/PlayersList.tsx
+++ b/frontend/src/components/SocialSidebar/PlayersList.tsx
@@ -59,6 +59,7 @@ export default function PlayersInTownList(): JSX.Element {
                           onClick={() => {
                             console.log('accept teleport confirm');
                             handleTeleport(player);
+                            onClose();
                           }}>
                           confirm
                         </Button>


### PR DESCRIPTION
When a user clicks on another username, instead of automatically teleporting, the user is asked via a notification to confirm their teleport request. If the user clicks yes on the notification, then the teleport occurs. If not, then the teleport does not happen and the notification goes away. 