### PR TITLE
37 teleport back button leads to teleport event with players previous coordinates using previous location

### DIFF
--- a/frontend/src/classes/PlayerController.ts
+++ b/frontend/src/classes/PlayerController.ts
@@ -15,7 +15,7 @@ export type PlayerGameObjects = {
 export default class PlayerController extends (EventEmitter as new () => TypedEmitter<PlayerEvents>) {
   private _location: PlayerLocation;
 
-  private _preTeleportLocation: PlayerLocation;
+  private _preTeleportLocation?: PlayerLocation | undefined;
 
   private readonly _id: string;
 
@@ -28,7 +28,6 @@ export default class PlayerController extends (EventEmitter as new () => TypedEm
     this._id = id;
     this._userName = userName;
     this._location = location;
-    this._preTeleportLocation = location;
   }
 
   set location(newLocation: PlayerLocation) {
@@ -41,11 +40,13 @@ export default class PlayerController extends (EventEmitter as new () => TypedEm
     return this._location;
   }
 
-  set preTeleportLocation(newLocation: PlayerLocation) {
-    this._preTeleportLocation = newLocation;
+  set preTeleportLocation(newLocation: PlayerLocation | undefined) {
+    if (newLocation) {
+      this._preTeleportLocation = newLocation;
+    }
   }
 
-  get preTeleportLocation(): PlayerLocation {
+  get preTeleportLocation(): PlayerLocation | undefined {
     return this._preTeleportLocation;
   }
 
@@ -63,18 +64,24 @@ export default class PlayerController extends (EventEmitter as new () => TypedEm
 
   public teleport(newLocation: PlayerLocation) {
     // change player location without walking animations
-    this._preTeleportLocation = this._location;
-    this._location = newLocation;
-    this._updateGameComponentLocation(true);
-    this.emit('movement', newLocation);
-  }
-
-  // DO NOT NEED
-  public teleportBack() {
-    // change player location without walking animations
-    this._location = this._preTeleportLocation;
-    this._updateGameComponentLocation(true);
-    this.emit('movement', this._location);
+    if (newLocation !== this._location) {
+      const tempLocation = {
+        x: this._location.x,
+        y: this._location.y,
+        rotation: this._location.rotation,
+        moving: this._location.moving,
+        interactableID: this._location.interactableID,
+      };
+      this._preTeleportLocation = tempLocation;
+      this._location = newLocation;
+      console.log('in PlayerController.teleport');
+      console.log(
+        'previous location:' + this._preTeleportLocation.x + ' ' + this._preTeleportLocation.y,
+      );
+      console.log('current location: ' + this._location.x + ' ' + this._location.y);
+      this._updateGameComponentLocation(true);
+      this.emit('movement', newLocation);
+    }
   }
 
   private _updateGameComponentLocation(teleport: boolean) {
@@ -85,6 +92,7 @@ export default class PlayerController extends (EventEmitter as new () => TypedEm
       }
       sprite.setX(this.location.x);
       sprite.setY(this.location.y);
+      console.log('in updateGameComponent');
       console.log('new location:' + sprite.x + ' ' + sprite.y);
       label.setX(this.location.x);
       label.setY(this.location.y - 20);

--- a/frontend/src/classes/TownController.ts
+++ b/frontend/src/classes/TownController.ts
@@ -545,12 +545,24 @@ export default class TownController extends (EventEmitter as new () => TypedEmit
   }
 
   public emitTeleportBack() {
-    this.ourPlayer.location.moving = false;
-    this._socket.emit('playerTeleport', this.ourPlayer.preTeleportLocation);
-    const ourPlayer = this._ourPlayer;
-    assert(ourPlayer);
-    ourPlayer.teleport(this.ourPlayer.preTeleportLocation);
-    this.emit('playerTeleported', ourPlayer);
+    console.log('teleport back emitter called');
+    if (this.ourPlayer.preTeleportLocation) {
+      this.ourPlayer.preTeleportLocation.moving = false;
+      console.log(
+        'previous location:' +
+          this.ourPlayer.preTeleportLocation.x +
+          ' ' +
+          this.ourPlayer.preTeleportLocation.y,
+      );
+      console.log(
+        'current location: ' + this.ourPlayer.location.x + ' ' + this.ourPlayer.location.y,
+      );
+      this._socket.emit('playerTeleport', this.ourPlayer.preTeleportLocation);
+      const ourPlayer = this._ourPlayer;
+      assert(ourPlayer);
+      ourPlayer.teleport(this.ourPlayer.preTeleportLocation);
+      this.emit('playerTeleported', ourPlayer);
+    }
   }
 
   /**

--- a/frontend/src/components/SocialSidebar/SocialSidebar.tsx
+++ b/frontend/src/components/SocialSidebar/SocialSidebar.tsx
@@ -6,6 +6,7 @@ import useTownController from '../../hooks/useTownController';
 
 export default function SocialSidebar(): JSX.Element {
   const townController = useTownController();
+
   const handleTeleportBack = () => {
     townController.emitTeleportBack();
   };
@@ -24,11 +25,13 @@ export default function SocialSidebar(): JSX.Element {
       <Heading fontSize='xl' as='h1'>
         Players In This Town
       </Heading>
-      <Button color='blue' onClick={() => {
-        console.log('teleport back');
-        handleTeleportBack();
-      }}>
-        tp back
+      <Button
+        color='blue'
+        onClick={() => {
+          console.log('teleport back');
+          handleTeleportBack();
+        }}>
+        Teleport Back
       </Button>
       <PlayersList />
       <ConversationAreasList />


### PR DESCRIPTION
Teleport back functionality complete. When a user presses the teleport back button, they will be teleported to the location they previously teleported from. 

* When a player presses teleport back and they have not teleported anywhere, the player will not move.
* If a player walks around, they will not be teleported to the location that they just teleported to, but the one before that. 
* PlayerController's previous location storage had a reference error. Updated PlayerController to store previous teleport location correctly. 