### PR TITLE
20 teleport request notification implemented with yes accept teleport and no deny teleport

### DIFF
--- a/frontend/src/classes/TownController.ts
+++ b/frontend/src/classes/TownController.ts
@@ -73,6 +73,11 @@ export type TownEvents = {
    */
   teleportRequested: (newRequest: TeleportRequest) => void;
   /**
+   * An event that indicates that a player has accepted a teleport request. This event is dispatched BEFORE updating the player's
+   * location. The player should be moved to the target player's location.
+   */
+  teleportAccepted: (acceptedRequest: TeleportRequest) => void;
+  /**
    * An event that indicates that the set of conversation areas has changed. This event is dispatched
    * when a conversation area is created, or when the set of active conversations has changed. This event is dispatched
    * after updating the town controller's record of conversation areas.
@@ -468,6 +473,26 @@ export default class TownController extends (EventEmitter as new () => TypedEmit
     });
 
     /**
+     * When a player accepts a teleport request, emit a player teleported event from the player
+     * who is teleporting.
+     */
+    this._socket.on('teleportAccepted', acceptedRequest => {
+      console.log('handling teleport accept');
+      const playerToUpdate = this.players.find(
+        eachPlayer => eachPlayer.id === acceptedRequest.from.id,
+      );
+      if (playerToUpdate) {
+        console.log('found player');
+        if (this._ourPlayer && playerToUpdate === this._ourPlayer) {
+          this.emitTeleport(PlayerController.fromPlayerModel(acceptedRequest.to));
+        }
+      } else {
+        console.log('could not find player');
+        console.log('looking for ' + acceptedRequest.from.userName);
+      }
+    });
+
+    /**
      * When a player requests to teleport another player, log that we received a request to teleport to our player
      */
     this._socket.on('teleportRequested', newRequest => {
@@ -558,7 +583,6 @@ export default class TownController extends (EventEmitter as new () => TypedEmit
       const newLocation = player.location;
       console.log('expected location: ' + player.location.x + ' ' + player.location.y);
       newLocation.moving = false;
-      newLocation.interactableID = this._viewingAreas[1].id;
       this._socket.emit('playerTeleport', newLocation);
       const ourPlayer = this._ourPlayer;
       assert(ourPlayer);
@@ -605,6 +629,29 @@ export default class TownController extends (EventEmitter as new () => TypedEmit
       console.log('our player:' + newRequest.from.userName);
       console.log('target player:' + newRequest.to.userName);
       this._socket.emit('teleportRequest', newRequest);
+    }
+  }
+
+  /**
+   * Emit a teleport event for an accepted teleport request accepted
+   * by our player.
+   *
+   * @param player: the player that this player is teleport to
+   */
+  public emitTeleportAccept(acceptedRequest: TeleportRequest) {
+    const ourPlayer = this._ourPlayer;
+    // confirm that we are the player who accepted the request.
+    if (ourPlayer && ourPlayer.id === acceptedRequest.to.id) {
+      console.log('emitting teleport accept to backend');
+      console.log(
+        `teleporting from ${acceptedRequest.from.userName} to ${acceptedRequest.to.userName}`,
+      );
+      this._socket.emit('teleportAccept', {
+        from: PlayerController.fromPlayerModel(acceptedRequest.from).toPlayerModel(),
+        to: PlayerController.fromPlayerModel(acceptedRequest.to).toPlayerModel(),
+      });
+    } else {
+      console.log('did not emit teleport accept');
     }
   }
 

--- a/frontend/src/components/SocialSidebar/PlayersList.tsx
+++ b/frontend/src/components/SocialSidebar/PlayersList.tsx
@@ -7,13 +7,13 @@ import {
   OrderedList,
   Tooltip,
   useToast,
-  ToastId,
 } from '@chakra-ui/react';
 import React from 'react';
 import PlayerController from '../../classes/PlayerController';
 import { usePlayers, useTeleportRequest } from '../../classes/TownController';
 import useTownController from '../../hooks/useTownController';
 import PlayerName from './PlayerName';
+import { TeleportRequest } from '../../types/CoveyTownSocket';
 
 /**
  * Lists the current players in the town, along with the current town's name and ID
@@ -40,6 +40,10 @@ export default function PlayersInTownList(): JSX.Element {
     townController.emitTeleportRequest(player);
   };
 
+  const handleTeleportAccept = (acceptedRequest: TeleportRequest) => {
+    townController.emitTeleportAccept(acceptedRequest);
+  };
+
   if (teleportRequest && teleportRequest.to.id === ourPlayer.id) {
     const { from } = teleportRequest;
     console.log('should toast');
@@ -55,7 +59,7 @@ export default function PlayersInTownList(): JSX.Element {
               color='green'
               onClick={() => {
                 console.log('accept teleport request');
-                // handleTeleportAccept(teleportRequest);
+                handleTeleportAccept(teleportRequest);
                 onClose();
               }}>
               confirm

--- a/shared/types/CoveyTownSocket.d.ts
+++ b/shared/types/CoveyTownSocket.d.ts
@@ -86,6 +86,7 @@ export interface ServerToClientEvents {
   playerJoined: (newPlayer: Player) => void;
   initialize: (initialData: TownJoinResponse) => void;
   teleportRequested: (newRequest: TeleportRequest) => void;
+  teleportAccepted: (acceptedRequest: TeleportRequest) => void;
   townSettingsUpdated: (update: TownSettingsUpdate) => void;
   teleportRequested: (fromPlayer: Player, toPlayer: Player) => void;
   townClosing: () => void;
@@ -98,6 +99,6 @@ export interface ClientToServerEvents {
   playerMovement: (movementData: PlayerLocation) => void;
   playerTeleport: (movementData: PlayerLocation) => void;
   teleportRequest: (newRequest: TeleportRequest) => void;
-  teleportAccept: (fromPlayer: Player, toPlayer: Player) => void;
+  teleportAccept: (acceptedRequest: TeleportRequest) => void;
   interactableUpdate: (update: Interactable) => void;
 }

--- a/townService/src/town/Town.ts
+++ b/townService/src/town/Town.ts
@@ -145,20 +145,20 @@ export default class Town {
     // Register an event listener for the client socket: if the client updates their
     // location, inform the CoveyTownController
     socket.on('playerMovement', (movementData: PlayerLocation) => {
-      this._updatePlayerLocation(newPlayer, movementData);
+      const movedPlayer = this._updatePlayerLocation(newPlayer, movementData);
+      this._broadcastEmitter.emit('playerMoved', movedPlayer.toPlayerModel());
     });
 
     // Register an event listener for the client socket: if the client updates their
     // location using teleport, inform the CoveyTownController
     socket.on('playerTeleport', (movementData: PlayerLocation) => {
-      this._updateAfterTeleport(newPlayer, movementData);
+      const movedPlayer = this._updatePlayerLocation(newPlayer, movementData);
+      this._broadcastEmitter.emit('playerTeleported', movedPlayer.toPlayerModel());
     });
 
     // Register an event listener for the client socket: if the client recieves a teleport
     // request, inform the CoveyTownController so the user can accept/decline
     socket.on('teleportRequest', (newRequest: TeleportRequest) => {
-      console.log('received request on backend.');
-      console.log(`from ${newRequest.from.userName} to ${newRequest.to.userName}`);
       this._broadcastEmitter.emit('teleportRequested', {
         from: newRequest.from,
         to: newRequest.to,
@@ -167,10 +167,15 @@ export default class Town {
 
     // Register an event listern for the client socket: if the client recieves an accept for
     // their teleport request, then move them to the player they requested
-    socket.on('teleportAccept', (fromPlayer, toPlayer) => {
-      if (newPlayer === fromPlayer) {
-        this._updateAfterTeleport(newPlayer, toPlayer.location);
-      }
+    socket.on('teleportAccept', (acceptedRequest: TeleportRequest) => {
+      console.log('in backend teleport accept');
+      console.log(
+        `teleporting from ${acceptedRequest.from.userName} to ${acceptedRequest.to.userName}`,
+      );
+      this._broadcastEmitter.emit('teleportAccepted', {
+        from: acceptedRequest.from,
+        to: acceptedRequest.to,
+      });
     });
 
     // Set up a listener to process updates to interactables.
@@ -230,7 +235,7 @@ export default class Town {
    * @param player Player to update location for
    * @param location New location for this player
    */
-  private _updatePlayerLocation(player: Player, location: PlayerLocation): void {
+  private _updatePlayerLocation(player: Player, location: PlayerLocation): Player {
     const prevInteractable = this._interactables.find(
       conv => conv.id === player.location.interactableID,
     );
@@ -253,43 +258,7 @@ export default class Town {
 
     player.location = location;
 
-    this._broadcastEmitter.emit('playerMoved', player.toPlayerModel());
-  }
-
-  /**
-   * Updates the location of a player within the town
-   *
-   * If the player has changed conversation areas, this method also updates the
-   * corresponding ConversationArea objects tracked by the town controller, and dispatches
-   * any onConversationUpdated events as appropriate
-   *
-   * @param player Player to update location for
-   * @param location New location for this player
-   */
-  private _updateAfterTeleport(player: Player, location: PlayerLocation): void {
-    const prevInteractable = this._interactables.find(
-      conv => conv.id === player.location.interactableID,
-    );
-
-    if (!prevInteractable?.contains(location)) {
-      if (prevInteractable) {
-        // Remove from old area
-        prevInteractable.remove(player);
-      }
-      const newInteractable = this._interactables.find(
-        eachArea => eachArea.isActive && eachArea.contains(location),
-      );
-      if (newInteractable) {
-        newInteractable.add(player);
-      }
-      location.interactableID = newInteractable?.id;
-    } else {
-      location.interactableID = prevInteractable.id;
-    }
-
-    player.location = location;
-
-    this._broadcastEmitter.emit('playerTeleported', player.toPlayerModel());
+    return player;
   }
 
   /**


### PR DESCRIPTION
Teleport request finished and works correctly. When a user A clicks on user B's username to teleport to them, user B will receive a request from user A asking to approve the teleport. If User B accepts the teleport, then user A will move to user B's location. If User B denies the teleport, then user A will not be teleported.

- Added teleportAccepted event to call playerTeleport event to the request sender.
- Revised teleportAccept to use the TeleportRequest data structure.