### PR TITLE
Isolated rendering for teleport request toast

### DIFF
--- a/frontend/src/classes/TownController.ts
+++ b/frontend/src/classes/TownController.ts
@@ -24,6 +24,7 @@ import ConversationAreaController from './ConversationAreaController';
 import PlayerController from './PlayerController';
 import ViewingAreaController from './ViewingAreaController';
 import PosterSessionAreaController from './PosterSessionAreaController';
+import { useToast } from '@chakra-ui/react';
 
 const CALCULATE_NEARBY_PLAYERS_DELAY = 300;
 
@@ -1017,9 +1018,12 @@ export function usePlayers(): PlayerController[] {
  */
 export function useTeleportRequest(): TeleportRequest | undefined {
   const townController = useTownController();
+  const { ourPlayer } = useTownController();
+  const toast = useToast();
   const [teleportRequest, setTeleportRequest] = useState<TeleportRequest | undefined>(
     townController.teleportRequest,
   );
+
   useEffect(() => {
     townController.addListener('teleportRequested', setTeleportRequest);
     return () => {

--- a/frontend/src/components/SocialSidebar/PlayersList.tsx
+++ b/frontend/src/components/SocialSidebar/PlayersList.tsx
@@ -27,7 +27,6 @@ export default function PlayersInTownList(): JSX.Element {
   const { ourPlayer } = useTownController();
   const sorted = players.concat([]);
   const toast = useToast();
-  const teleportRequest = useTeleportRequest();
   sorted.sort((p1, p2) =>
     p1.userName.localeCompare(p2.userName, undefined, { numeric: true, sensitivity: 'base' }),
   );
@@ -35,49 +34,6 @@ export default function PlayersInTownList(): JSX.Element {
   const handleTeleportRequest = (player: PlayerController) => {
     townController.emitTeleportRequest(player);
   };
-
-  const handleTeleportAccept = (acceptedRequest: TeleportRequest) => {
-    townController.emitTeleportAccept(acceptedRequest);
-  };
-
-  if (teleportRequest && teleportRequest.to.id === ourPlayer.id) {
-    const { from } = teleportRequest;
-    console.log('should toast');
-    toast({
-      position: 'bottom-left',
-      duration: 10000,
-      render: ({ onClose }) => (
-        <Box color='white' p={3} bg='blue.500'>
-          {from.userName} is trying to teleport to you. Would you like to accept?
-          <HStack>
-            <Button
-              size='xs'
-              color='green'
-              onClick={() => {
-                console.log('accept teleport request');
-                handleTeleportAccept(teleportRequest);
-                onClose();
-              }}>
-              confirm
-            </Button>
-            <Button
-              size='xs'
-              color='red'
-              onClick={() => {
-                console.log('denied teleport request');
-                onClose();
-              }}>
-              deny
-            </Button>
-          </HStack>
-        </Box>
-      ),
-    });
-  } else if (!teleportRequest) {
-    console.log('teleport request undefined');
-  } else {
-    console.log('teleport request does not match');
-  }
 
   return (
     <Box>
@@ -90,33 +46,35 @@ export default function PlayersInTownList(): JSX.Element {
         {sorted.map(player => (
           <ListItem key={player.id}>
             <Button
-              onClick={() =>
-                toast({
-                  position: 'bottom-left',
-                  duration: 10000,
-                  render: ({ onClose }) => (
-                    <Box color='white' p={3} bg='blue.500'>
-                      Would you like to teleport to {player.userName}?
-                      <HStack>
-                        <Button
-                          size='xs'
-                          color='green'
-                          onClick={() => {
-                            console.log('accept teleport confirm');
-                            // handleTeleport(player);
-                            handleTeleportRequest(player);
-                            onClose();
-                          }}>
-                          confirm
-                        </Button>
-                        <Button size='xs' color='red' onClick={onClose}>
-                          deny
-                        </Button>
-                      </HStack>
-                    </Box>
-                  ),
-                })
-              }>
+              onClick={() => {
+                if (ourPlayer.id !== player.id) {
+                  toast({
+                    position: 'bottom-left',
+                    duration: 10000,
+                    render: ({ onClose }) => (
+                      <Box color='white' p={3} bg='blue.500'>
+                        Would you like to teleport to {player.userName}?
+                        <HStack>
+                          <Button
+                            size='xs'
+                            color='green'
+                            onClick={() => {
+                              console.log('accept teleport confirm');
+                              // handleTeleport(player);
+                              handleTeleportRequest(player);
+                              onClose();
+                            }}>
+                            confirm
+                          </Button>
+                          <Button size='xs' color='red' onClick={onClose}>
+                            deny
+                          </Button>
+                        </HStack>
+                      </Box>
+                    ),
+                  });
+                }
+              }}>
               <PlayerName player={player} />
             </Button>
           </ListItem>

--- a/frontend/src/components/SocialSidebar/SocialSidebar.tsx
+++ b/frontend/src/components/SocialSidebar/SocialSidebar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ConversationAreasList from './ConversationAreasList';
 import PlayersList from './PlayersList';
 import useTownController from '../../hooks/useTownController';
+import TeleportManager from './TeleportManager';
 
 export default function SocialSidebar(): JSX.Element {
   const townController = useTownController();
@@ -35,6 +36,7 @@ export default function SocialSidebar(): JSX.Element {
       </Button>
       <PlayersList />
       <ConversationAreasList />
+      <TeleportManager />
     </VStack>
   );
 }

--- a/frontend/src/components/SocialSidebar/TeleportManager.tsx
+++ b/frontend/src/components/SocialSidebar/TeleportManager.tsx
@@ -1,0 +1,59 @@
+import { Box, Button, HStack, VisuallyHidden, useToast } from '@chakra-ui/react';
+import React from 'react';
+import ConversationAreasList from './ConversationAreasList';
+import PlayersList from './PlayersList';
+import useTownController from '../../hooks/useTownController';
+import { useTeleportRequest } from '../../classes/TownController';
+import { TeleportRequest } from '../../types/CoveyTownSocket';
+
+export default function TeleportManager(): JSX.Element {
+  const townController = useTownController();
+  const { ourPlayer } = useTownController();
+  const toast = useToast();
+  const teleportRequest = useTeleportRequest();
+
+  const handleTeleportAccept = (acceptedRequest: TeleportRequest) => {
+    townController.emitTeleportAccept(acceptedRequest);
+  };
+
+  if (teleportRequest && teleportRequest.to.id === ourPlayer.id) {
+    const { from } = teleportRequest;
+    console.log('should toast');
+    toast({
+      position: 'bottom-left',
+      duration: 10000,
+      render: ({ onClose }) => (
+        <Box color='white' p={3} bg='blue.500'>
+          {from.userName} is trying to teleport to you. Would you like to accept?
+          <HStack>
+            <Button
+              size='xs'
+              color='green'
+              onClick={() => {
+                console.log('accept teleport request');
+                handleTeleportAccept(teleportRequest);
+                onClose();
+              }}>
+              confirm
+            </Button>
+            <Button
+              size='xs'
+              color='red'
+              onClick={() => {
+                console.log('denied teleport request');
+                onClose();
+              }}>
+              deny
+            </Button>
+          </HStack>
+        </Box>
+      ),
+    });
+  } else if (!teleportRequest) {
+    console.log('teleport request undefined');
+  } else {
+    console.log('teleport request not addressed to our player');
+  }
+
+  return <VisuallyHidden>Mock Element</VisuallyHidden>;
+}


### PR DESCRIPTION
When players leave and join, it does not seem like toasts are rerendering. Toast and teleport listeners are isolated for teleport request, but not for teleport confirm toast. Need to confirm when deployed that the teleport confirm toasts do not render twice.